### PR TITLE
feat(exam,daily): include questionId in exam results & add isLastDay flag

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/daily/UserDailyDto.java
+++ b/src/main/java/com/qriz/sqld/dto/daily/UserDailyDto.java
@@ -25,6 +25,7 @@ public class UserDailyDto {
     private boolean reviewDay;
     private boolean comprehensiveReviewDay;
     private boolean isToday;
+    private boolean isLastDay;
 
     public UserDailyDto(UserDaily userDaily) {
         this.id = userDaily.getId();

--- a/src/main/java/com/qriz/sqld/dto/exam/ExamTestResult.java
+++ b/src/main/java/com/qriz/sqld/dto/exam/ExamTestResult.java
@@ -144,6 +144,7 @@ public class ExamTestResult {
     @Getter
     @AllArgsConstructor
     public static class ResultDto {
+        private Long questionId;
         private int questionNum;
         private String skillName;
         private String question;

--- a/src/main/java/com/qriz/sqld/service/daily/DailyPlanService.java
+++ b/src/main/java/com/qriz/sqld/service/daily/DailyPlanService.java
@@ -317,17 +317,22 @@ public class DailyPlanService {
         boolean candidateFound = false;
         for (UserDailyDto dto : dtos) {
             if (!candidateFound) {
-                // 1. planDate가 오늘인 경우
-                if (dto.getPlanDate().isEqual(today)) {
-                    dto.setToday(true); // Lombok이 생성한 setter는 setToday()
+                // 0. Day30 완료 후에도 Today로 표시
+                if ("Day30".equals(dto.getDayNumber()) && dto.isCompleted()) {
+                    dto.setToday(true);
                     candidateFound = true;
                 }
-                // 2. 오늘 완료된 경우 (완료되었어도 오늘 진행한 것으로 표시)
+                // 1. planDate가 오늘인 경우
+                else if (dto.getPlanDate().isEqual(today)) {
+                    dto.setToday(true);
+                    candidateFound = true;
+                }
+                // 2. 오늘 완료된 경우
                 else if (dto.getCompletionDate() != null && dto.getCompletionDate().isEqual(today)) {
                     dto.setToday(true);
                     candidateFound = true;
                 }
-                // 3. planDate가 오늘보다 이전이고 아직 완료되지 않은 경우(overdue)
+                // 3. planDate가 오늘보다 이전이고 아직 완료되지 않은 경우
                 else if (dto.getPlanDate().isBefore(today) && !dto.isCompleted()) {
                     dto.setToday(true);
                     candidateFound = true;
@@ -337,6 +342,11 @@ public class DailyPlanService {
             } else {
                 dto.setToday(false);
             }
+        }
+
+        for (UserDailyDto dto : dtos) {
+            // Day30이면서 완료된 경우에만 isLastDay=true
+            dto.setLastDay("Day30".equals(dto.getDayNumber()) && dto.isCompleted());
         }
 
         return dtos;

--- a/src/main/java/com/qriz/sqld/service/exam/ExamService.java
+++ b/src/main/java/com/qriz/sqld/service/exam/ExamService.java
@@ -313,6 +313,7 @@ public class ExamService {
                 List<ExamTestResult.ResultDto> resultDtos = userActivityRepository.findByExamSession(latestSession)
                                 .stream()
                                 .map(activity -> new ExamTestResult.ResultDto(
+                                                activity.getQuestion().getId(),
                                                 activity.getQuestionNum(),
                                                 activity.getQuestion().getSkill().getKeyConcepts(),
                                                 activity.getQuestion().getQuestion(),


### PR DESCRIPTION
모의고사 결과 API 개선: ResultDto에 questionId 필드 추가 및 매핑 반영

- ExamTestResult.ResultDto에 questionId 프로퍼티 추가
- ExamService.getExamResults()에서 questionId 매핑 로직 수정

Daily:
• UserDailyDto에 isLastDay 속성 도입
• DailyPlanService.getUserDailyPlan()에서 완료된 Day30에 대해 isLastDay=true 설정