### PR TITLE
feat(daily): include questionId in DailyResultDto & fix email validation

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
+++ b/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
@@ -57,6 +57,7 @@ public class DaySubjectDetailsDto {
     @Getter
     @AllArgsConstructor
     public static class DailyResultDto {
+        private Long questionId;
         private String skillName;
         private String question;
         private boolean correction;

--- a/src/main/java/com/qriz/sqld/dto/user/UserReqDto.java
+++ b/src/main/java/com/qriz/sqld/dto/user/UserReqDto.java
@@ -68,7 +68,7 @@ public class UserReqDto {
     @Setter
     public static class FindUsernameReqDto {
         @NotEmpty
-        @Pattern(regexp = "^[a-zA-Z0-9]{2,10}@[a-zA-Z0-9]{2,6}\\.[a-zA-Z]{2,3}$", message = "이메일 형식으로 작성해주세요")
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]{2,64}@[a-zA-Z0-9.-]{2,255}\\.[a-zA-Z]{2,10}$", message = "이메일 형식으로 작성해주세요")
         private String email;
     }
 

--- a/src/main/java/com/qriz/sqld/service/daily/DailyService.java
+++ b/src/main/java/com/qriz/sqld/service/daily/DailyService.java
@@ -341,6 +341,7 @@ public class DailyService {
 
             // 문제별 상세 결과 DTO 추가
             dailyResults.add(new DaySubjectDetailsDto.DailyResultDto(
+                    question.getId(),
                     title,
                     question.getQuestion(),
                     activity.isCorrection()));


### PR DESCRIPTION
- DaySubjectDetailsDto.DailyResultDto에 questionId 필드 추가  
- DailyService.getDaySubjectDetails()에서 questionId 매핑 반영  
- 아이디 찾기(find-id) 시 이메일 유효성 검사 로직 수정