### PR TITLE
feat: ApplicationDetail DateTimeFormatter 에 한국어 로케일 적용

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/application/ApplicationRespDto.java
+++ b/src/main/java/com/qriz/sqld/dto/application/ApplicationRespDto.java
@@ -2,6 +2,7 @@ package com.qriz.sqld.dto.application;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import com.qriz.sqld.domain.application.Application;
 
@@ -31,9 +32,9 @@ public class ApplicationRespDto {
             private String releaseDate;
 
             public ApplicationDetail(Application application) {
-                DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM.dd(E)");
-                DateTimeFormatter testDateFormatter = DateTimeFormatter.ofPattern("M월 d일(E)");
-                DateTimeFormatter releaseDateFormatter = DateTimeFormatter.ofPattern("M월 d일");
+                DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM.dd(E)", Locale.KOREAN);
+                DateTimeFormatter testDateFormatter = DateTimeFormatter.ofPattern("M월 d일(E)", Locale.KOREAN);
+                DateTimeFormatter releaseDateFormatter = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREAN);
 
                 this.applyId = application.getId();
                 this.examName = application.getExamName();


### PR DESCRIPTION
## 변경 사항
- `ApplicationDetail` 생성자 내 `DateTimeFormatter`를 만들 때 `Locale.KOREAN`을 명시적으로 지정
  - `period`: `MM.dd(E)` → `MM.dd(E), Locale.KOREAN`
  - `examDate`: `M월 d일(E)` → `M월 d일(E), Locale.KOREAN`
  - `releaseDate`: `M월 d일` → `M월 d일, Locale.KOREAN`
  
## 배경
서버 기본 로케일이 영어로 되어 있는 환경에서 요일 표기가 “Mon, Sat” 등 영어로 노출되던 문제를 해결하기 위함

## 체크리스트
- [x] `period`, `examDate`, `releaseDate` 필드의 요일이 한글(예: `(토)`)로 잘 노출되는지 확인
- [x] 전체 API 응답에 영향이 없는지 테스트

