### PR TITLE
refactor: withdraw() method with safe deletion logic for related data

### DIFF
--- a/src/main/java/com/qriz/sqld/domain/apply/UserApplyRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/apply/UserApplyRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.qriz.sqld.domain.user.User;
 
@@ -20,6 +21,7 @@ public interface UserApplyRepository extends JpaRepository<UserApply, Long> {
     Optional<UserApply> findUserApplyByUserId(@Param("userId") Long userId);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM UserApply ua WHERE ua.user = :user")
     void deleteByUser(@Param("user") User user);
 

--- a/src/main/java/com/qriz/sqld/domain/daily/UserDailyRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/daily/UserDailyRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.qriz.sqld.domain.user.User;
 
@@ -30,6 +31,7 @@ public interface UserDailyRepository extends JpaRepository<UserDaily, Long> {
         List<UserDaily> findAllByUserId(Long userId);
 
         @Modifying
+        @Transactional
         @Query("DELETE FROM UserDaily ud where ud.user = :user")
         void deleteByUser(@Param("user") User user);
 
@@ -62,4 +64,8 @@ public interface UserDailyRepository extends JpaRepository<UserDaily, Long> {
         @Query("SELECT ud FROM UserDaily ud LEFT JOIN FETCH ud.plannedSkills WHERE ud.user.id = :userId AND ud.dayNumber = :dayNumber AND ud.isArchived = false")
         Optional<UserDaily> findByUserIdAndDayNumberAndIsArchivedFalse(@Param("userId") Long userId,
                         @Param("dayNumber") String dayNumber);
+
+        @Modifying
+        @Transactional
+        List<UserDaily> findByUser(User user);
 }

--- a/src/main/java/com/qriz/sqld/domain/exam/UserExamSessionRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/exam/UserExamSessionRepository.java
@@ -5,9 +5,13 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.qriz.sqld.domain.user.User;
 
 @Repository
 public interface UserExamSessionRepository extends JpaRepository<UserExamSession, Long> {
@@ -51,4 +55,9 @@ public interface UserExamSessionRepository extends JpaRepository<UserExamSession
          * @return 가장 최근 완료된 UserExamSession, 없으면 Optional.empty()
          */
         Optional<UserExamSession> findFirstByUserIdOrderByCompletionDateDesc(Long userId);
+
+        @Modifying
+        @Transactional
+        @Query("DELETE FROM UserExamSession use WHERE use.user = :user")
+        void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/com/qriz/sqld/domain/preview/UserPreviewTestRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/preview/UserPreviewTestRepository.java
@@ -4,6 +4,7 @@ import com.qriz.sqld.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,6 +22,7 @@ public interface UserPreviewTestRepository extends JpaRepository<UserPreviewTest
     Optional<UserPreviewTest> findFirstByUserAndCompletedOrderByCompletionDateDesc(User user, boolean completed);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM UserPreviewTest upt WHERE upt.user = :user")
     void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/com/qriz/sqld/domain/skillLevel/SkillLevelRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/skillLevel/SkillLevelRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -30,6 +31,7 @@ public interface SkillLevelRepository extends JpaRepository<SkillLevel, Long> {
     List<SkillLevel> findTop3ByUserIdOrderByCurrentAccuracyAsc(Long userId);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM SkillLevel sl WHERE sl.user = :user")
     void deleteByUser(@Param("user") User user);
 

--- a/src/main/java/com/qriz/sqld/domain/survey/SurveyRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/survey/SurveyRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.qriz.sqld.domain.user.User;
 
@@ -26,6 +27,7 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
     Optional<Survey> findByUserAndKnowsNothingTrue(User user);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM Survey s WHERE s.user = :user")
     void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/com/qriz/sqld/domain/user/UserRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/user/UserRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -18,6 +19,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNicknameAndEmail(String nickname, String email);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM User u WHERE u = :user")
     void delete(@Param("user") User user);
 }

--- a/src/main/java/com/qriz/sqld/mail/domain/EmailVerification/EmailVerificationRepository.java
+++ b/src/main/java/com/qriz/sqld/mail/domain/EmailVerification/EmailVerificationRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +16,8 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
     Optional<EmailVerification> findByEmailAndAuthNumberAndVerifiedFalse(String email, String authNumber);
 
     // 특정 이메일의 모든 인증 정보 삭제
+    @Modifying
+    @Transactional
     void deleteByEmail(String email);
 
     // 특정 이메일의 최근 인증 시도 횟수 조회 (최근 10분 이내)

--- a/src/main/java/com/qriz/sqld/mail/domain/PasswordResetToken/PasswordResetTokenRepository.java
+++ b/src/main/java/com/qriz/sqld/mail/domain/PasswordResetToken/PasswordResetTokenRepository.java
@@ -3,8 +3,13 @@ package com.qriz.sqld.mail.domain.PasswordResetToken;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
     Optional<PasswordResetToken> findByEmailAndTokenAndUsedFalse(String email, String token);
+    
+    @Modifying
+    @Transactional
     void deleteByEmail(String email);
 }


### PR DESCRIPTION
### 📌 배경
- 회원 탈퇴(withdraw) 시 bulk DELETE만 사용할 경우 FK 제약 오류가 발생  
- user_activity → clipped, user_daily_skills → user_daily 순으로 자식 테이블을 먼저 삭제해야 함

### 🌟 변경 사항
1. UserActivity → Clipped 관계에 `cascade = REMOVE, orphanRemoval = true` 매핑 추가  
2. withdraw() 로직에서
   - `userActivityRepository.findByUserId()` → `deleteAll(activities)` 호출로 cascade 삭제  
   - `daily.getPlannedSkills().clear()` + `userDailyRepository.flush()` 로 조인 테이블 정리  
   - 자식 테이블 순서(Clipped → UserActivity → UserDaily → … → User)로 삭제 순서 재배치  
3. 각 `deleteByUser()` 메소드에 `@Modifying`·`@Transactional` 검증

### 🔍 검증 방법
- Postman 등으로 회원 탈퇴 API 호출 → FK 오류 없이 관련 데이터(활동, 클립, 플랜, 설문 등) 모두 삭제 확인  
- 단위/통합 테스트로 withdraw() 동작 커버리지 추가
