### PR TITLE
refactor: consolidate application endpoints under /api/v1/applications

### DIFF
--- a/src/main/java/com/qriz/sqld/controller/ApplyController.java
+++ b/src/main/java/com/qriz/sqld/controller/ApplyController.java
@@ -17,31 +17,32 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/applications")
 public class ApplyController {
 
     private final ApplyService applyService;
 
     // 시험 접수 목록 조회
-    @GetMapping("/application-list")
+    @GetMapping
     public ResponseEntity<?> getApplicationList(@AuthenticationPrincipal LoginUser loginUser) {
         ApplicationRespDto.ApplyListRespDto applyListRespDto = applyService.applyList(loginUser);
         return new ResponseEntity<>(new ResponseDto<>(1, "시험 접수 목록 불러오기 성공", applyListRespDto), HttpStatus.OK);
     }
 
     // 시험 접수
-    @PostMapping("/apply")
+    @PostMapping
     public ResponseEntity<?> apply(@AuthenticationPrincipal LoginUser loginUser,
             @RequestBody @Valid ApplicationReqDto.ApplyReqDto applyReqDto) {
 
-        System.out.println("applyReqDto = " + applyReqDto);
-        ApplicationRespDto.ApplyRespDto applyRespDto = applyService.apply(applyReqDto, loginUser);
-        return new ResponseEntity<>(new ResponseDto<>(1, "시험 등록 성공", applyRespDto), HttpStatus.OK);
+        ApplicationRespDto.ApplyRespDto applyRespDto = applyService.apply(applyReqDto.getApplyId(), loginUser);
+        return new ResponseEntity<>(new ResponseDto<>(1, "시험 등록 성공", applyRespDto), HttpStatus.CREATED);
     }
 
     // 등록한 시험 접수 정보 조회
@@ -69,16 +70,14 @@ public class ApplyController {
     }
 
     // 접수 정보 변경
-    @PostMapping("/apply-modify")
+    @PatchMapping("/{uaId}")
     public ResponseEntity<?> modifyApplication(
+            @PathVariable Long uaId,
             @AuthenticationPrincipal LoginUser loginUser,
             @RequestBody @Valid ApplicationReqDto.ModifyReqDto modifyReqDto) {
-        ApplicationRespDto.ApplyRespDto modifyRespDto = applyService.modifyApplication(modifyReqDto, loginUser);
+        ApplicationRespDto.ApplyRespDto modifyRespDto = applyService.modifyApplication(uaId, modifyReqDto.getNewApplyId(), loginUser);
         return new ResponseEntity<>(
                 new ResponseDto<>(1, "시험 접수 변경 성공", modifyRespDto),
                 HttpStatus.OK);
     }
-
-    // 시험 등록 취소
-
 }

--- a/src/main/java/com/qriz/sqld/domain/apply/UserApplyRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/apply/UserApplyRepository.java
@@ -1,5 +1,6 @@
 package com.qriz.sqld.domain.apply;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,4 +29,7 @@ public interface UserApplyRepository extends JpaRepository<UserApply, Long> {
     @Query("SELECT ua FROM UserApply ua WHERE ua.user.id = :userId AND ua.application.id = :applicationId")
     Optional<UserApply> findByUserIdAndApplicationId(@Param("userId") Long userId,
             @Param("applicationId") Long applicationId);
+
+    @Query("SELECT ua FROM UserApply ua WHERE ua.user.id = :userId")
+    List<UserApply> findAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/qriz/sqld/dto/application/ApplicationRespDto.java
+++ b/src/main/java/com/qriz/sqld/dto/application/ApplicationRespDto.java
@@ -15,28 +15,33 @@ public class ApplicationRespDto {
     @Setter
     public static class ApplyListRespDto {
         private Long registeredApplicationId;
+        private Long registeredUserApplyId;
         private List<ApplicationDetail> applications;
 
-        public ApplyListRespDto(Long registeredApplicationId, List<ApplicationDetail> applications) {
+        public ApplyListRespDto(Long registeredApplicationId, Long registeredUserApplyId,
+                List<ApplicationDetail> applications) {
             this.registeredApplicationId = registeredApplicationId;
+            this.registeredUserApplyId = registeredUserApplyId;
             this.applications = applications;
         }
 
         @Getter
         @Setter
         public static class ApplicationDetail {
-            private Long applyId;
+            private Long applicationId;
+            private Long userApplyId;
             private String examName;
             private String period;
             private String examDate;
             private String releaseDate;
 
-            public ApplicationDetail(Application application) {
+            public ApplicationDetail(Application application, Long userApplyId) {
                 DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM.dd(E)", Locale.KOREAN);
                 DateTimeFormatter testDateFormatter = DateTimeFormatter.ofPattern("M월 d일(E)", Locale.KOREAN);
                 DateTimeFormatter releaseDateFormatter = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREAN);
 
-                this.applyId = application.getId();
+                this.applicationId = application.getId();
+                this.userApplyId = userApplyId;
                 this.examName = application.getExamName();
                 // 접수 기간 포맷 수정
                 this.period = application.getStartDate().format(dateFormatter) + " 10:00 ~ "


### PR DESCRIPTION
### 변경 사항
- `/api/v1/applications` 로 시험 접수 관련 모든 엔드포인트 통합
  - GET    /applications           → 목록 조회(+ userApplyId 포함)
  - POST   /applications           → 신규 접수
  - PATCH  /applications/{uaId}    → 접수 정보 수정
- ApplyService 시그니처 및 로직 수정
- UserApplyRepository 에 findAllByUser_Id() 추가
- ApplyListRespDto 에 registeredUserApplyId 및 ApplicationDetail.userApplyId 추가

### 목적
- 하나의 리소스 경로로 CRUD 구분해 RESTful 일관성 확보  
- 클라이언트가 userApplyId 로 바로 PATCH 요청 가능하도록 개선