### PR TITLE
refactor: remove skillId field from DaySubjectDetailsDto.SubjectDetails

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
+++ b/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
@@ -19,17 +19,15 @@ public class DaySubjectDetailsDto {
 
     @Getter
     public static class SubjectDetails {
-        private Long skillId;
         private String title;
         private double totalScore;
         private List<ItemScore> items = new ArrayList<>();
 
-        public SubjectDetails(Long skillId, String title) {
-            this.skillId = skillId;
+        public SubjectDetails(String title) {
             this.title = title;
         }
 
-        public void addScore(String type, double score) {
+        public void addScore(Long skillId, String type, double score) {
             ItemScore existing = items.stream()
                     .filter(i -> i.getType().equals(type))
                     .findFirst()

--- a/src/main/java/com/qriz/sqld/service/daily/DailyService.java
+++ b/src/main/java/com/qriz/sqld/service/daily/DailyService.java
@@ -353,8 +353,8 @@ public class DailyService {
 
             // SubjectDetails 객체 생성 또는 가져와서 해당 type으로 점수 누적
             subjectDetailsMap
-                    .computeIfAbsent(skillId, id -> new DaySubjectDetailsDto.SubjectDetails(id, title))
-                    .addScore(type, score);
+                    .computeIfAbsent(skillId, id -> new DaySubjectDetailsDto.SubjectDetails(title))
+                    .addScore(skillId, type, score);
 
             // 문제별 상세 결과 DTO 추가
             dailyResults.add(new DaySubjectDetailsDto.DailyResultDto(


### PR DESCRIPTION
### 변경사항
- `DaySubjectDetailsDto.SubjectDetails` 에서 `skillId` 필드 제거  
- 서비스 로직(`subjectDetailsMap.computeIfAbsent`)에서 DTO 생성자 호출부를 `new SubjectDetails(title)`로 변경
- 서비스 로직(`DailyService.getDaySubjectDetails`)의

  ```java
  .computeIfAbsent(...).addScore(type, score)
  ```
  호출부를
  
   ```java

  .computeIfAbsent(...).addScore(skillId, type, score)
  ```
  로 수정

### 목적
- `userDailyInfoList` 응답에는 `skillId`가 필요 없고, `title`·`totalScore`·`items` 정보만으로 충분하므로 API 응답 단순화  
- DTO 구조를 가볍게 만들어 가독성 및 유지보수성 향상