### PR TITLE
refactor: use map for detailType-score in DaySubjectDetailsDto response

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
+++ b/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
@@ -1,7 +1,7 @@
 package com.qriz.sqld.dto.daily;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,42 +13,13 @@ public class DaySubjectDetailsDto {
     public static class Response {
         private String dayNumber;
         private boolean passed;
-        private List<SubjectDetails> userDailyInfoList;
+        private Map<String, Double> items;
         private List<DailyResultDto> subjectResultsList;
-    }
 
-    @Getter
-    public static class SubjectDetails {
-        private String title;
-        private double totalScore;
-        private List<ItemScore> items = new ArrayList<>();
-
-        public SubjectDetails(String title) {
-            this.title = title;
-        }
-
-        public void addScore(Long skillId, String type, double score) {
-            ItemScore existing = items.stream()
-                    .filter(i -> i.getType().equals(type))
-                    .findFirst()
-                    .orElse(null);
-
-            if (existing == null) {
-                items.add(new ItemScore(skillId, type, score));
-            } else {
-                existing.addScore(score);
-            }
-            totalScore += score;
-        }
-
-        public void adjustTotalScore() {
-            if (totalScore > 100) {
-                double factor = 100.0 / totalScore;
-                totalScore = 100.0;
-                for (ItemScore item : items) {
-                    item.adjustScore(factor);
-                }
-            }
+        public double getTotalScore() {
+            return items.values().stream()
+                    .mapToDouble(Double::doubleValue)
+                    .sum();
         }
     }
 
@@ -56,24 +27,8 @@ public class DaySubjectDetailsDto {
     @AllArgsConstructor
     public static class DailyResultDto {
         private Long questionId;
-        private String skillName;
+        private String detailType;
         private String question;
         private boolean correction;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class ItemScore {
-        private Long skillId;
-        private String type;
-        private double score;
-
-        public void addScore(double additionalScore) {
-            this.score += additionalScore;
-        }
-
-        public void adjustScore(double factor) {
-            this.score *= factor;
-        }
     }
 }


### PR DESCRIPTION
### 변경사항
- `getDaySubjectDetails`에서 기존 `SubjectDetails` DTO 대신  
  `Map<String, Double> items` (detailType → score) 형태로 반환하도록 수정  
- `Response` DTO에 `items` 맵과 `subjectResultsList`만 남기고,  
  `totalScore`는 `items` 값들의 합으로 getter에서 자동 계산  
- 서비스 로직에서 `items.merge(detailType, score, Double::sum)` 으로 점수 누적

### 목적
- 세부 항목별 점수를 배열이 아닌 키-값 형태로 제공해 응답을 단순화  
- 프론트엔드에서 바로 `"items":{"조인":40.0, ...}` 형태로 사용하기 용이  

### 확인
- API 호출 시 아래와 같은 구조로 응답되는지 확인 필요  
  ```json
  {
    "dayNumber": "Day1",
    "passed": false,
    "items": {
      "조인": 40.0,
      "SELECT 문": 25.0
    },
    "totalScore": 65.0,
    "subjectResultsList": [ ... ]
  }
