### PR TITLE
Add weekly review API and prevent duplicate exam registration

### DIFF
--- a/src/main/java/com/qriz/sqld/domain/apply/UserApplyRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/apply/UserApplyRepository.java
@@ -32,4 +32,6 @@ public interface UserApplyRepository extends JpaRepository<UserApply, Long> {
 
     @Query("SELECT ua FROM UserApply ua WHERE ua.user.id = :userId")
     List<UserApply> findAllByUserId(@Param("userId") Long userId);
+
+    boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
+++ b/src/main/java/com/qriz/sqld/dto/daily/DaySubjectDetailsDto.java
@@ -1,7 +1,6 @@
 package com.qriz.sqld.dto.daily;
 
 import java.util.List;
-import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,15 +9,24 @@ public class DaySubjectDetailsDto {
 
     @Getter
     @AllArgsConstructor
+    public static class SubItemDto {
+        private Long skillId;
+        private double score;
+    }
+
+    @Getter
+    @AllArgsConstructor
     public static class Response {
         private String dayNumber;
         private boolean passed;
-        private Map<String, Double> items;
+        private boolean reviewDay;
+        private boolean comprehensiveReviewDay;
+        private List<SubItemDto> items;
         private List<DailyResultDto> subjectResultsList;
 
         public double getTotalScore() {
-            return items.values().stream()
-                    .mapToDouble(Double::doubleValue)
+            return items.stream()
+                    .mapToDouble(SubItemDto::getScore)
                     .sum();
         }
     }
@@ -30,5 +38,53 @@ public class DaySubjectDetailsDto {
         private String detailType;
         private String question;
         private boolean correction;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class WeeklyReviewDto {
+        private String dayNumber;
+        private boolean passed;
+        private boolean reviewDay;
+        private boolean comprehensiveReviewDay;
+        private double totalScore;
+        private List<SimpleMajorItem> majorItems;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SimpleMajorItem {
+        private String majorItem;
+        private double score;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class WeeklyReviewRspDto {
+        private List<DailySubjectDetails> subjects;
+        private double totalScore;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class DailySubjectDetails {
+        private String title; // "1과목", "2과목"
+        private double totalScore;
+        private List<MajorItemDetail> majorItems;
+
+        @Getter
+        @AllArgsConstructor
+        public static class MajorItemDetail {
+            private String majorItem; // 예: "데이터 모델과 SQL"
+            private double score;
+            private List<SubItemScore> subItemScores;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        public static class SubItemScore {
+            private String subItem; // 예: "정규화"
+            private double score;
+        }
     }
 }

--- a/src/main/java/com/qriz/sqld/service/apply/ApplyService.java
+++ b/src/main/java/com/qriz/sqld/service/apply/ApplyService.java
@@ -65,20 +65,25 @@ public class ApplyService {
         public ApplicationRespDto.ApplyRespDto apply(Long applicationId, LoginUser loginUser) {
                 Long userId = loginUser.getUser().getId();
 
-                // 1. 해당 사용자가 해당 시험에 접수 중인지 확인
+                // 1. 이미 어떤 시험에 접수된 상태인지 체크 (새로 접수 불가)
+                if (userApplyRepository.existsByUserId(userId)) {
+                        throw new CustomApiException("이미 다른 시험에 접수 중이므로, 새로 접수할 수 없습니다.");
+                }
+
+                // 2. 해당 사용자가 해당 시험에 접수 중인지 확인
                 if (userApplyRepository.existsByUserIdAndApplicationId(userId, applicationId)) {
                         throw new CustomApiException("이미 해당 시험에 접수하였습니다.");
                 }
 
-                // 2. 시험이 존재하는지 확인
+                // 3. 시험이 존재하는지 확인
                 Application application = applicationRepository.findById(applicationId)
                                 .orElseThrow(() -> new CustomApiException("존재하지 않는 시험입니다."));
 
-                // 3. 사용자 접수 정보 생성
+                // 4. 사용자 접수 정보 생성
                 UserApply userApply = new UserApply(loginUser.getUser(), application);
                 userApplyRepository.save(userApply);
 
-                // 4. 응답 데이터 생성
+                // 5. 응답 데이터 생성
                 DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM-dd");
                 String period = formatPeriod(application.getStartDate(), application.getEndDate());
 


### PR DESCRIPTION
## 변경사항
1. **DailyController & DailyService**  
   - `GET /api/v1/daily/weekly-reviews/{day}` 엔드포인트 및 `getWeeklyReviewBySubject` 메서드 추가  
   - 파라미터(subject1/subject2) 처리, 과목별·전체 주간 점수 집계 구현  

2. **ApplyController & ApplyService**  
   - 시험 접수 시 중복 접수 방지를 위한 검증 로직 추가  
     - 이미 다른 시험에 접수 중인 경우 예외 반환  
     - 동일 시험에 중복 접수 시 예외 반환  

## 테스트
1. `/api/v1/daily/weekly-reviews/1` 호출 → 모든 과목의 주간 결과 확인  
2. `/api/v1/daily/weekly-reviews/1?subject=subject1` 호출 → 1과목 결과만 반환  
3. 신규 사용자로 `POST /api/v1/applications` 호출 → 정상 등록(201)  
4. 같은 사용자로 다른 시험 ID 등록 → “이미 다른 시험에 접수 중” 예외  
5. 같은 사용자로 동일 시험 ID 재등록 → “이미 해당 시험에 접수하였습니다.” 예외
