### PR TITLE
Prevent NonUniqueResultException by adding DISTINCT to UserDaily fetch

### DIFF
--- a/src/main/java/com/qriz/sqld/domain/daily/UserDailyRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/daily/UserDailyRepository.java
@@ -15,7 +15,7 @@ import com.qriz.sqld.domain.user.User;
 
 @Repository
 public interface UserDailyRepository extends JpaRepository<UserDaily, Long> {
-        @Query("SELECT DISTINCT ud FROM UserDaily ud LEFT JOIN FETCH ud.plannedSkills WHERE ud.user.id = :userId ORDER BY ud.planDate ASC")
+        @Query("SELECT DISTINCT ud FROM UserDaily ud LEFT JOIN FETCH ud.plannedSkills WHERE ud.user.id = :userId AND ud.isArchived = false ORDER BY ud.planDate ASC")
         List<UserDaily> findByUserIdWithPlannedSkillsOrderByPlanDateAsc(@Param("userId") Long userId);
 
         @Query("SELECT ud FROM UserDaily ud LEFT JOIN FETCH ud.plannedSkills WHERE ud.user.id = :userId AND ud.dayNumber = :dayNumber")
@@ -61,9 +61,11 @@ public interface UserDailyRepository extends JpaRepository<UserDaily, Long> {
                         "ORDER BY ud.archivedAt DESC")
         List<UserDaily> findByUserIdAndArchivedTrueOrderByArchivedAtDesc(@Param("userId") Long userId);
 
-        @Query("SELECT ud FROM UserDaily ud LEFT JOIN FETCH ud.plannedSkills WHERE ud.user.id = :userId AND ud.dayNumber = :dayNumber AND ud.isArchived = false")
+        @Query("SELECT DISTINCT ud FROM UserDaily ud LEFT JOIN FETCH ud.plannedSkills WHERE ud.user.id = :userId AND ud.dayNumber = :dayNumber AND ud.isArchived = false")
         Optional<UserDaily> findByUserIdAndDayNumberAndIsArchivedFalse(@Param("userId") Long userId,
                         @Param("dayNumber") String dayNumber);
+
+        boolean existsByUserIdAndDayNumberAndIsArchivedFalse(Long userId, String dayNumber);
 
         @Modifying
         @Transactional


### PR DESCRIPTION
### 변경사항
- `UserDailyRepository.findByUserIdAndDayNumberAndIsArchivedFalse` JPQL에 `SELECT DISTINCT ud` 추가  
  - `LEFT JOIN FETCH ud.plannedSkills` 시 스킬 수만큼 중복된 UserDaily가 반환되던 문제 해결

### 발생 문제  
- 하루에 스킬이 2개 이상 할당된 경우, 단일 결과 조회 메서드가 중복 행을 받아 `NonUniqueResultException` 발생  

### 해결  
- `SELECT DISTINCT ud`를 사용해 중복된 조인 결과를 하나로 합쳐 정상적으로 단일 엔티티가 반환되도록 수정  

### 검증 방법
1. 배포된 서버에서 `/api/v1/daily/weekly-reviews/1` 호출 시 에러 없이 정상 응답  
2. 스킬 2개 이상 할당된 Day에 대해서도 올바른 주간 복습 결과 확인
