### PR TITLE
refactor: load UserActivity with clips for cascade delete in withdraw()

### DIFF
--- a/src/main/java/com/qriz/sqld/domain/UserActivity/UserActivityRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/UserActivity/UserActivityRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -58,4 +59,11 @@ public interface UserActivityRepository extends JpaRepository<UserActivity, Long
 
         // 프리뷰 테스트 삭제용
         void deleteByUserIdAndTestInfo(Long userId, String testInfo);
+
+        @Transactional
+        @Query("SELECT ua " +
+                        "  FROM UserActivity ua " +
+                        "  LEFT JOIN FETCH ua.clips " +
+                        " WHERE ua.user.id = :userId")
+        List<UserActivity> findByUserIdWithClips(@Param("userId") Long userId);
 }

--- a/src/main/java/com/qriz/sqld/domain/clip/ClipRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/clip/ClipRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.qriz.sqld.domain.UserActivity.UserActivity;
 import com.qriz.sqld.domain.daily.UserDaily;
@@ -163,4 +164,11 @@ public interface ClipRepository extends JpaRepository<Clipped, Long> {
         // UserDaily의 planVersion을 기준으로 Clipped 데이터 삭제
         @Query("DELETE FROM Clipped c WHERE c.userActivity.userDaily.planVersion = :planVersion AND c.userActivity.user.id = :userId")
         void deleteByUserDailyPlanVersion(@Param("userId") Long userId, @Param("planVersion") int planVersion);
+
+        @Transactional
+        @Query("SELECT ua " +
+                        "  FROM UserActivity ua " +
+                        "  LEFT JOIN FETCH ua.clips " +
+                        " WHERE ua.user.id = :userId")
+        List<UserActivity> findByUserIdWithClips(@Param("userId") Long userId);
 }

--- a/src/main/java/com/qriz/sqld/service/user/UserService.java
+++ b/src/main/java/com/qriz/sqld/service/user/UserService.java
@@ -167,7 +167,7 @@ public class UserService {
         }
 
         // 1) user_activity 먼저
-        List<UserActivity> activities = userActivityRepository.findByUserId(userId);
+        List<UserActivity> activities = userActivityRepository.findByUserIdWithClips(userId);
         userActivityRepository.deleteAll(activities);
 
         List<UserDaily> dailies = userDailyRepository.findByUser(user);


### PR DESCRIPTION
### 변경 사항
- `UserActivityRepository`에 `findByUserIdWithClips(Long userId)` 메소드 추가 (LEFT JOIN FETCH ua.clips)
- `UserService.withdraw()` 로직 수정  
  1. `findByUserIdWithClips(userId)` 호출  
  2. `deleteAll(activities)`로 JPA `CascadeType.REMOVE` 활용하여 `Clipped` 엔티티 자동 삭제  
  3. 기존 수동 `clipRepository.deleteByUserId()` 호출 제거

### 변경 이유
기존에는 bulk DELETE나 수동 JPQL을 사용해 `Clipped` 데이터를 삭제했기 때문에  
- MySQL 문법 오류가 발생하거나  
- JPA cascade가 적용되지 않아 FK 제약 오류가 발생  

이제 엔티티 기반 삭제 흐름으로 전환해, 외래 키 제약 없이 안전하게 연관 데이터를 삭제합니다.

### 검증 방법
- [ ] 클립된 데이터가 있는 사용자에 대해 withdraw API 호출 → `clipped`, `user_activity` 등 관련 테이블 데이터가 FK 오류 없이 모두 삭제되는지 확인  
