### PR TITLE
feat: elimintate duplicate preview question and add frequency-based fallback

### DIFF
--- a/src/main/java/com/qriz/sqld/domain/question/QuestionRepository.java
+++ b/src/main/java/com/qriz/sqld/domain/question/QuestionRepository.java
@@ -113,4 +113,35 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
                         List<Long> skillIds,
                         int category,
                         Pageable pageable);
+
+        /**
+         * 중복 배제를 위해 excludeIds를 받아서 랜덤 질문 조회
+         */
+        @Query(value = ""
+                        + "SELECT * FROM question q "
+                        + "WHERE q.skill_id IN (:skillIds) "
+                        + "  AND q.category = :category "
+                        + "  AND q.question_id NOT IN (:excludeIds) "
+                        + "ORDER BY RAND() "
+                        + "LIMIT :limit", nativeQuery = true)
+        List<Question> findRandomQuestionsBySkillIdsAndCategoryExcluding(
+                        @Param("skillIds") List<Long> skillIds,
+                        @Param("category") int category,
+                        @Param("excludeIds") List<Long> excludeIds,
+                        @Param("limit") int limit);
+
+        // 새 메서드: frequency 내림차순 + 랜덤
+        @Query(value = ""
+                        + "SELECT q.* FROM question q "
+                        + "  JOIN skill s ON q.skill_id = s.skill_id "
+                        + "WHERE q.skill_id IN (:skillIds) "
+                        + "  AND q.category = :category "
+                        + "  AND q.question_id NOT IN (:excludeIds) "
+                        + "ORDER BY s.frequency DESC, RAND() "
+                        + "LIMIT :limit", nativeQuery = true)
+        List<Question> findRandomQuestionsBySkillIdsAndCategoryExcludingOrderByFreq(
+                        @Param("skillIds") List<Long> skillIds,
+                        @Param("category") int category,
+                        @Param("excludeIds") List<Long> excludeIds,
+                        @Param("limit") int limit);
 }


### PR DESCRIPTION
### 원인
- `getStratifiedRandomQuestions()`에서 1차 보충 후 최종 중복 제거와 부족분 보충 로직이 분리되어 있어, 동일한 문항이 두 번 이상 리스트에 포함되는 이슈가 발생함

### 해결 방법
1. `findRandomQuestionsBySkillIdsAndCategoryExcluding` 메서드로 1차 보충 시 중복 배제  
2. `LinkedHashMap`을 사용해 ID 기준 최종 dedupe  
3. `findRandomQuestionsBySkillIdsAndCategoryExcludingOrderByFreq` 쿼리로 부족분 2차 보충 (skill.frequency Desc + RAND())  
4. 마지막으로 셔플 후 정확히 21문항만 잘라내도록 로직 통합

### 배포 후 체크 리스트
- [x] QA 환경에서 설문조사에서 선택된 개념 기반으로 21문항이 내려오는지 확인  
- [x] 반환된 질문 리스트에 중복 문항이 없는지 검증  
- [ ] 부족분 보충 시 frequency 높은 개념 문항이 우선 포함되는지 확인  
- [x] 쿼리 응답 시간에 급격한 지연이 없는지 모니터링 