### PR TITLE
feat: Add Locale.KOREAN to DateTimeFormatter patterns for Korean weekday abbreviations

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/application/ApplicationRespDto.java
+++ b/src/main/java/com/qriz/sqld/dto/application/ApplicationRespDto.java
@@ -75,8 +75,8 @@ public class ApplicationRespDto {
         private String examDate;
 
         public AppliedRespDto(Application application) {
-            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM.dd(E)");
-            DateTimeFormatter testDateFormatter = DateTimeFormatter.ofPattern("M월 d일(E)");
+            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM.dd(E)", Locale.KOREAN);
+            DateTimeFormatter testDateFormatter = DateTimeFormatter.ofPattern("M월 d일(E)", Locale.KOREAN);
 
             this.examName = application.getExamName();
             // 접수 기간 포맷 수정

--- a/src/main/java/com/qriz/sqld/service/apply/ApplyService.java
+++ b/src/main/java/com/qriz/sqld/service/apply/ApplyService.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -84,7 +85,7 @@ public class ApplyService {
                 userApplyRepository.save(userApply);
 
                 // 5. 응답 데이터 생성
-                DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM-dd");
+                DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM-dd", Locale.KOREAN);
                 String period = formatPeriod(application.getStartDate(), application.getEndDate());
 
                 return new ApplicationRespDto.ApplyRespDto(
@@ -128,7 +129,7 @@ public class ApplyService {
         }
 
         private String formatPeriod(LocalDate startDate, LocalDate endDate) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM.dd(E)");
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM.dd(E)", Locale.KOREAN);
                 return startDate.format(formatter) + " ~ " + endDate.format(formatter);
         }
 
@@ -158,7 +159,7 @@ public class ApplyService {
                 userApplyRepository.save(ua); // Update
 
                 // 5. 응답 데이터 생성
-                DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM-dd");
+                DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM-dd", Locale.KOREAN);
                 String period = formatPeriod(newApp.getStartDate(), newApp.getEndDate());
 
                 return new ApplicationRespDto.ApplyRespDto(


### PR DESCRIPTION
**요약**
- 날짜 포맷터에 `Locale.KOREAN` 을 적용해 요일이 한글(`(월)`, `(화)`…)로 표시되도록 수정

**변경사항**
- `ApplyService.formatPeriod()`  
  - `DateTimeFormatter.ofPattern("MM.dd(E)")` → `DateTimeFormatter.ofPattern("MM.dd(E)", Locale.KOREAN)`  
- `AppliedRespDto` 생성자 및 `ApplyListRespDto.ApplicationDetail` 생성자  
  - 모든 `DateTimeFormatter.ofPattern("…(E)…")` 호출에 `Locale.KOREAN` 추가  
- (선택) `apply()` 및 `modifyApplication()` 응답 포맷터에도 일관성 있게 로케일 지정  

**검증 방법**
- API 호출 후 JSON 응답의 `period` 값이 `"07.21(월) ~ 07.25(금)"` 형태로 출력되는지 확인  
- `examDate`, `releaseDate` 등에 `(E)` 패턴이 있는 경우 한글 요일이 정상 표시되는지 확인  

**참고**
기존 JVM 기본 로케일이 영어여서 `(Mon)`, `(Tue)` 등으로 나오던 문제를 해결