### PR TITLE
Enhance session score calculation, sub-item filtering, and null optionId handling

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/exam/ExamRespDto.java
+++ b/src/main/java/com/qriz/sqld/dto/exam/ExamRespDto.java
@@ -4,12 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public class ExamRespDto {
-    
+
     @Getter
     @AllArgsConstructor
     public static class SessionList {
         private boolean completed;
+        private Long examId;
         private String session;
-        private String totalScore;
+        private Double totalScore;
     }
 }


### PR DESCRIPTION
### 배경
- `/session-list` API가 String 타입의 totalScore를 반환하며, 단순 저장된 subject1/subject2 합으로 올바르지 않은 점수가 노출.
- `/subject-details` API가 사용자가 응답하지 않은 모든 subItem을 함께 반환하여 불필요한 데이터가 포함.
- 시험 제출 시 optionId가 null인 경우 NPE가 발생.

### 해결 방법
1. SessionList DTO의 totalScore를 String → Double로 변경.
2. getSessionList에서 userExamSession에 저장된 점수가 아닌, getSubjectScoreDetails로 계산된 실제 과목 점수를 합산하도록 수정.
3. getSubjectScoreDetails에서 사용자가 답안 activity로 제출한 subItem만 SubjectDetails에 추가하도록 필터링 로직을 적용.
4. 시험 제출 로직에 optionId null 체크를 추가하여, 누락 시 400 Bad Request로 응답하도록 예외 처리를 보완.

### 반영 후 확인사항
- [ ] `/api/v1/exam/session-list` 호출 시 totalScore가 Double 타입으로 실제 합계로 반환되는지  
- [ ] `/api/v1/exam/{examId}/subject-details` 호출 시 응답에 실제 응답한 subItem만 포함되는지 