### PR TITLE
feat: custom access (3m) and refresh (5m) token expiry for user test1234

### DIFF
--- a/src/main/java/com/qriz/sqld/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/qriz/sqld/config/jwt/JwtAuthorizationFilter.java
@@ -17,6 +17,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -35,66 +36,161 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
+    // @Override
+    // protected void doFilterInternal(HttpServletRequest request,
+    // HttpServletResponse response, FilterChain chain)
+    // throws IOException, ServletException {
+
+    // if (isHeaderVerify(request, response)) {
+    // String accessToken =
+    // request.getHeader(JwtVO.HEADER).replace(JwtVO.TOKEN_PREFIX, "");
+
+    // try {
+    // // Access Token 검증
+    // if (JwtProcess.isTokenValid(accessToken)) {
+    // LoginUser loginUser = JwtProcess.verify(accessToken);
+    // authenticateUser(loginUser);
+    // } else {
+    // // Access Token이 만료된 경우
+    // LoginUser loginUser = JwtProcess.verifyAndExtractUser(accessToken); // 수정된
+    // 메서드 사용
+    // Long userId = loginUser.getUser().getId();
+
+    // // RefreshToken을 DB에서 조회
+    // Optional<RefreshToken> refreshTokenOptional =
+    // refreshTokenRepository.findById(userId);
+
+    // if (refreshTokenOptional.isPresent()) {
+    // RefreshToken refreshTokenEntity = refreshTokenOptional.get();
+    // String refreshToken = refreshTokenEntity.getToken();
+
+    // if (JwtProcess.isTokenValid(refreshToken)) {
+    // // 새로운 Access Token 발급
+    // String newAccessToken = JwtProcess.createAccessToken(loginUser);
+    // response.setHeader(JwtVO.HEADER, JwtVO.TOKEN_PREFIX + newAccessToken);
+
+    // // Refresh Token 만료 3일 이내 체크
+    // if (JwtProcess.isTokenExpiringNear(refreshToken, 60 * 24 * 3)) { // 3일
+    // // 새로운 Refresh Token 발급
+    // String newRefreshToken = JwtProcess.createRefreshToken(loginUser);
+
+    // // DB의 Refresh Token 업데이트
+    // refreshTokenEntity.updateToken(
+    // newRefreshToken,
+    // LocalDateTime.now().plusSeconds(JwtVO.REFRESH_TOKEN_EXPIRATION_TIME));
+    // refreshTokenRepository.save(refreshTokenEntity);
+
+    // log.debug("Refresh Token 자동 갱신 완료");
+    // }
+
+    // authenticateUser(loginUser);
+    // } else {
+    // response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token
+    // expired");
+    // return;
+    // }
+    // } else {
+    // response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token not
+    // found");
+    // return;
+    // }
+    // }
+    // } catch (Exception e) {
+    // log.error("토큰 검증 실패", e);
+    // response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
+    // return;
+    // }
+    // }
+
+    // chain.doFilter(request, response);
+    // }
+
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain)
             throws IOException, ServletException {
 
         if (isHeaderVerify(request, response)) {
-            String accessToken = request.getHeader(JwtVO.HEADER).replace(JwtVO.TOKEN_PREFIX, "");
+            // 클라이언트에서 보낸 액세스 토큰 (prefix 제거)
+            String accessToken = request.getHeader(JwtVO.HEADER)
+                    .replace(JwtVO.TOKEN_PREFIX, "");
 
             try {
-                // Access Token 검증
+                // 1) 액세스 토큰이 유효한 경우
                 if (JwtProcess.isTokenValid(accessToken)) {
                     LoginUser loginUser = JwtProcess.verify(accessToken);
                     authenticateUser(loginUser);
+
                 } else {
-                    // Access Token이 만료된 경우
-                    LoginUser loginUser = JwtProcess.verifyAndExtractUser(accessToken); // 수정된 메서드 사용
+                    // 2) 액세스 토큰 만료된 경우, 사용자 정보만 추출
+                    LoginUser loginUser = JwtProcess.verifyAndExtractUser(accessToken);
                     Long userId = loginUser.getUser().getId();
 
-                    // RefreshToken을 DB에서 조회
+                    // DB에서 리프레시 토큰 조회
                     Optional<RefreshToken> refreshTokenOptional = refreshTokenRepository.findById(userId);
 
                     if (refreshTokenOptional.isPresent()) {
                         RefreshToken refreshTokenEntity = refreshTokenOptional.get();
                         String refreshToken = refreshTokenEntity.getToken();
 
+                        // 3) 리프레시 토큰이 유효하면 액세스 토큰 재발급
                         if (JwtProcess.isTokenValid(refreshToken)) {
-                            // 새로운 Access Token 발급
-                            String newAccessToken = JwtProcess.createAccessToken(loginUser);
-                            response.setHeader(JwtVO.HEADER, JwtVO.TOKEN_PREFIX + newAccessToken);
+                            // 사용자별 액세스 토큰 만료시간 결정
+                            long accessExpMs = JwtVO.ACCESS_TOKEN_EXPIRATION_TIME;
+                            if ("test1234".equals(loginUser.getUser().getUsername())) {
+                                accessExpMs = 1000L * 60 * 3; // 3분
+                            }
+                            String newAccessToken = JwtProcess.createAccessToken(loginUser, accessExpMs);
+                            response.setHeader(
+                                    JwtVO.HEADER,
+                                    JwtVO.TOKEN_PREFIX + newAccessToken);
 
-                            // Refresh Token 만료 3일 이내 체크
-                            if (JwtProcess.isTokenExpiringNear(refreshToken, 60 * 24 * 3)) { // 3일
-                                // 새로운 Refresh Token 발급
-                                String newRefreshToken = JwtProcess.createRefreshToken(loginUser);
+                            // 4) 리프레시 토큰 만료 임박(3일 이내) 체크 후 재발급
+                            if (JwtProcess.isTokenExpiringNear(refreshToken, 60 * 24 * 3)) {
+                                long refreshExpMs = JwtVO.REFRESH_TOKEN_EXPIRATION_TIME;
+                                if ("test1234".equals(loginUser.getUser().getUsername())) {
+                                    refreshExpMs = 1000L * 60 * 5; // 5분
+                                }
+                                String newRefreshToken = JwtProcess.createRefreshToken(loginUser, refreshExpMs);
 
-                                // DB의 Refresh Token 업데이트
-                                refreshTokenEntity.updateToken(
-                                        newRefreshToken,
-                                        LocalDateTime.now().plusSeconds(JwtVO.REFRESH_TOKEN_EXPIRATION_TIME));
+                                // DB 저장용으로 prefix 제거 후 만료시간 적용
+                                String rawToken = newRefreshToken.substring(JwtVO.TOKEN_PREFIX.length());
+                                LocalDateTime expireAt = LocalDateTime.now()
+                                        .plus(Duration.ofMillis(refreshExpMs));
+
+                                refreshTokenEntity.updateToken(rawToken, expireAt);
                                 refreshTokenRepository.save(refreshTokenEntity);
-
                                 log.debug("Refresh Token 자동 갱신 완료");
                             }
 
                             authenticateUser(loginUser);
+
                         } else {
-                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token expired");
+                            // 리프레시 토큰 만료 시
+                            response.sendError(
+                                    HttpServletResponse.SC_UNAUTHORIZED,
+                                    "Refresh token expired");
                             return;
                         }
                     } else {
-                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token not found");
+                        // DB에 리프레시 토큰이 없을 때
+                        response.sendError(
+                                HttpServletResponse.SC_UNAUTHORIZED,
+                                "Refresh token not found");
                         return;
                     }
                 }
             } catch (Exception e) {
                 log.error("토큰 검증 실패", e);
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
+                response.sendError(
+                        HttpServletResponse.SC_UNAUTHORIZED,
+                        "Invalid token");
                 return;
             }
         }
 
+        // 다음 필터 또는 컨트롤러로 요청 전달
         chain.doFilter(request, response);
     }
 

--- a/src/main/java/com/qriz/sqld/config/jwt/JwtProcess.java
+++ b/src/main/java/com/qriz/sqld/config/jwt/JwtProcess.java
@@ -20,27 +20,57 @@ import com.qriz.sqld.domain.user.UserEnum;
 public class JwtProcess {
     private static final Logger log = LoggerFactory.getLogger(JwtProcess.class);
 
-    public static String createAccessToken(LoginUser loginUser) {
-        String jwtToken = JWT.create()
+    // public static String createAccessToken(LoginUser loginUser) {
+    // String jwtToken = JWT.create()
+    // .withSubject("access_token")
+    // .withExpiresAt(new Date(System.currentTimeMillis() +
+    // JwtVO.ACCESS_TOKEN_EXPIRATION_TIME * 1000L))
+    // .withClaim("id", loginUser.getUser().getId())
+    // .withClaim("role", loginUser.getUser().getRole() + "")
+    // .withClaim("previewStatus",
+    // loginUser.getUser().getPreviewTestStatus() != null
+    // ? loginUser.getUser().getPreviewTestStatus().name()
+    // : PreviewTestStatus.NOT_STARTED.name())
+    // .sign(Algorithm.HMAC512(JwtVO.SECRET));
+    // return JwtVO.TOKEN_PREFIX + jwtToken;
+    // }
+
+    // public static String createRefreshToken(LoginUser loginUser) {
+    // String jwtToken = JWT.create()
+    // .withSubject("refresh_token")
+    // .withExpiresAt(new Date(System.currentTimeMillis() +
+    // JwtVO.REFRESH_TOKEN_EXPIRATION_TIME * 1000L))
+    // .withClaim("id", loginUser.getUser().getId())
+    // .sign(Algorithm.HMAC512(JwtVO.SECRET));
+    // return JwtVO.TOKEN_PREFIX + jwtToken;
+    // }
+
+    public static String createAccessToken(LoginUser loginUser, long expirationMillis) {
+        String jwt = JWT.create()
                 .withSubject("access_token")
-                .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.ACCESS_TOKEN_EXPIRATION_TIME * 1000L))
+                .withExpiresAt(new Date(System.currentTimeMillis() + expirationMillis))
                 .withClaim("id", loginUser.getUser().getId())
-                .withClaim("role", loginUser.getUser().getRole() + "")
-                .withClaim("previewStatus",
-                        loginUser.getUser().getPreviewTestStatus() != null
-                                ? loginUser.getUser().getPreviewTestStatus().name()
-                                : PreviewTestStatus.NOT_STARTED.name())
+                .withClaim("role", loginUser.getUser().getRole().name())
+                .withClaim("previewStatus", loginUser.getUser().getPreviewTestStatus().name())
                 .sign(Algorithm.HMAC512(JwtVO.SECRET));
-        return JwtVO.TOKEN_PREFIX + jwtToken;
+        return JwtVO.TOKEN_PREFIX + jwt;
+    }
+
+    public static String createAccessToken(LoginUser loginUser) {
+        return createAccessToken(loginUser, JwtVO.ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public static String createRefreshToken(LoginUser loginUser, long expirationMillis) {
+        String jwt = JWT.create()
+                .withSubject("refresh_token")
+                .withExpiresAt(new Date(System.currentTimeMillis() + expirationMillis))
+                .withClaim("id", loginUser.getUser().getId())
+                .sign(Algorithm.HMAC512(JwtVO.SECRET));
+        return JwtVO.TOKEN_PREFIX + jwt;
     }
 
     public static String createRefreshToken(LoginUser loginUser) {
-        String jwtToken = JWT.create()
-                .withSubject("refresh_token")
-                .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.REFRESH_TOKEN_EXPIRATION_TIME * 1000L))
-                .withClaim("id", loginUser.getUser().getId())
-                .sign(Algorithm.HMAC512(JwtVO.SECRET));
-        return JwtVO.TOKEN_PREFIX + jwtToken;
+        return createRefreshToken(loginUser, JwtVO.REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
     public static LoginUser verify(String token) {


### PR DESCRIPTION
### 배경
- 요구사항에 따라 특정 사용자(test1234)에 한해 액세스 토큰 만료 시간을 3분, 리프레시 토큰 만료 시간을 5분으로 단축

### 주요 변경사항
1. `JwtAuthenticationFilter`와 `JwtAuthorizationFilter`에 사용자별 만료시간 분기 로직 추가  
   - username이 "test1234"인 경우 access token = 3분, refresh token = 5분  
   - 그 외 사용자는 기존 기본 설정(6시간/60일) 유지  
2. `Duration.ofMillis(...)` 적용하여 `LocalDateTime` 만료시간 계산 오류 수정

### 검증 방법
- **test1234**로 로그인 후  
  - 응답 헤더 `Authorization`의 access token 만료 시간이 약 3분 뒤인지 확인  
  - DB에 저장된 `refresh_token` 만료 시간이 약 5분 뒤로 설정됐는지 확인  
- **일반 사용자**로 로그인하여 기본 만료시간(6시간/60일)이 정상 작동하는지 확인