### PR TITLE
fix: remove duplicate 'Bearer' prefix in JWT response header

### DIFF
--- a/src/main/java/com/qriz/sqld/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/qriz/sqld/config/jwt/JwtAuthorizationFilter.java
@@ -158,7 +158,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                             String newAccessToken = JwtProcess.createAccessToken(loginUser, accessExpMs);
                             response.setHeader(
                                     JwtVO.HEADER,
-                                    JwtVO.TOKEN_PREFIX + newAccessToken);
+                                    newAccessToken);
 
                             // 4) 리프레시 토큰 만료 임박(3일 이내) 체크 후 재발급
                             if (JwtProcess.isTokenExpiringNear(refreshToken, 60 * 24 * 3)) {


### PR DESCRIPTION
### 배경
- JWT 토큰을 생성할 때 `createAccessToken()` 메서드가 이미 `"Bearer "`를 붙여 리턴하는데,
  `JwtAuthorizationFilter`에서 다시 `JwtVO.TOKEN_PREFIX`를 덧붙이고 있었음
- 그 결과 응답 헤더에 `Authorization: "Bearer Bearer <토큰본문>"` 형태로 중복되어 노출되는 버그가 관측됨

### 주요 변경사항
`JwtAuthorizationFilter`에서
   - `response.setHeader(JwtVO.HEADER, JwtVO.TOKEN_PREFIX + newAccessToken)` 부분을
     ```java
     response.setHeader(JwtVO.HEADER, newAccessToken)
     ```
     로 수정하여, `createAccessToken()`이 이미 포함한 `Bearer `를 중복으로 덧붙이지 않도록 변경


### 검증 방법
- **테스트 시나리오**  
  1. `test1234` 계정으로 로그인 → Access/Refresh 토큰 발급  
  2. 액세스 토큰이 만료된 상태(3분)에서 인증이 필요한 엔드포인트 호출  
     - 응답 헥더(`Authorization`)에 `"Bearer <토큰본문>"` 형태로 한 번만 붙어 있는지 확인  
     - 더 이상 `"Bearer Bearer ..." `가 아닌지 검증  

- **Postman 예시**  
  - 요청 헤더: `Authorization: Bearer <만료된 토큰>`  
  - 응답 헤더:  
    ```
    Authorization: Bearer eyJ0eXAiOiJKV…   ← Bearer가 한 번만 붙어야 함
    ```
  - 두 번 중복되지 않는지 반드시 확인

