### PR TITLE
refactor: delete RefreshToken on user withdrawal

### DIFF
--- a/src/main/java/com/qriz/sqld/service/user/UserService.java
+++ b/src/main/java/com/qriz/sqld/service/user/UserService.java
@@ -10,6 +10,7 @@ import com.qriz.sqld.domain.survey.SurveyRepository;
 import com.qriz.sqld.domain.user.User;
 import com.qriz.sqld.domain.user.UserRepository;
 import com.qriz.sqld.dto.user.UserReqDto;
+import com.qriz.sqld.config.auth.RefreshTokenRepository;
 import com.qriz.sqld.domain.UserActivity.UserActivity;
 import com.qriz.sqld.domain.UserActivity.UserActivityRepository;
 import com.qriz.sqld.dto.user.UserRespDto;
@@ -52,6 +53,7 @@ public class UserService {
     private final UserExamSessionRepository userExamSessionRepository;
     private final EmailVerificationRepository emailVerificationRepository;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final RestTemplate restTemplate;
 
     @Value("${oauth2.google.client-id}")
@@ -201,7 +203,12 @@ public class UserService {
         emailVerificationRepository.deleteByEmail(user.getEmail());
         passwordResetTokenRepository.deleteByEmail(user.getEmail());
 
-        // 10) 최종 User 삭제
+        // 10) RefreshToken
+        if (refreshTokenRepository.existsById(userId)) {
+            refreshTokenRepository.deleteById(userId);
+        }
+
+        // 11) 최종 User 삭제
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
### 🛠 변경 사항
- 회원 탈퇴(withdraw) 시 RefreshToken 삭제 로직 추가  
  - `RefreshTokenRepository.deleteById(userId)` 호출로 해당 사용자의 리프레시 토큰 제거

### 🚀 변경 이유
이제 회원 탈퇴 시 유효한 리프레시 토큰이 남아 있으면 보안 취약점이 발생할 수 있으므로, 탈퇴 로직에 리프레시 토큰 삭제를 추가하여 모든 인증 데이터를 완전히 제거

### ✅ 검증 방법
- [ ] 클립, UserActivity 등 기존 연관 데이터 삭제 후에 `refresh_token` 테이블에서 해당 `userId` 레코드가 삭제되는지 확인  
- [ ] 단위/통합 테스트에서 `refreshTokenRepository.findById(userId)` 결과가 `Optional.empty()` 로 나오는지 검증  