### PR TITLE
feat: add session list filtering/sorting and remove refresh token on logout

### DIFF
--- a/src/main/java/com/qriz/sqld/dto/exam/ExamRespDto.java
+++ b/src/main/java/com/qriz/sqld/dto/exam/ExamRespDto.java
@@ -12,5 +12,9 @@ public class ExamRespDto {
         private Long examId;
         private String session;
         private Double totalScore;
+
+        public boolean isCompleted() {
+            return completed;
+        }
     }
 }


### PR DESCRIPTION
### 주요 수정사항

- 모의고사 세션 리스트 조회 API에 상태(status)별 필터링(전체/미완료/완료) 및 정렬(오름차순/내림차순) 기능 추가
- 로그아웃 시 DB에서 해당 유저의 refresh 토큰 정보를 삭제하도록 수정

---

### 수정 배경

- 유저가 모의고사 학습 상태(완료/미완료)에 따라 세션 리스트를 구분하여 확인할 수 있도록 개선
- 보안 강화를 위해 로그아웃 시 refresh 토큰을 DB에서 삭제하여 재사용을 방지

---

### 반영 후 체크리스트

- [ ] status, sort 파라미터별로 모의고사 세션 리스트가 정상적으로 조회되는지 확인
- [ ] 로그아웃 시 refresh 토큰이 DB에서 정상적으로 삭제되는지 확인